### PR TITLE
Run all things as wiki user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,3 +33,11 @@ RUN a2enmod authz_groupfile \
 
 # Updated Apache configuration.
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
+
+# Add user and update php-fpm to use it.
+# We'll leave `listen.group` set to `www-data` so Apache can talk to the socker.
+RUN set -ex; \
+  adduser --shell /bin/bash --disabled-password --gecos "Wiki User" --uid 4415 wiki; \
+  sed -i -e 's/^user .*/user = wiki/' /etc/php/7.0/fpm/pool.d/www.conf; \
+  sed -i -e 's/^group .*/group = wiki/' /etc/php/7.0/fpm/pool.d/www.conf; \
+  sed -i -e 's/^listen.owner.*/listen.owner = wiki/' /etc/php/7.0/fpm/pool.d/www.conf;

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -63,5 +63,5 @@ fi
 ## Docker image pull, don't bother if building as we'll separate checks there.
 if [ -z "$BUILD" ]; then
   echo "==> Checking for local copy of required docker images..."
-  docker-compose pull
+  sudo -E docker-compose pull
 fi

--- a/script/update
+++ b/script/update
@@ -32,6 +32,7 @@ VIRTUALENV_DIR=${VIRTUALENV_DIR:-venv}
 source ${VIRTUALENV_DIR}/bin/activate
 
 echo "==> Building configuration..."
+umask 027
 for template_file in conf/*.j2 ; do
   build_conf $template_file ${template_file%%.j2}
   cp ${template_file%%.j2} ${template_file%%.j2}.deployed


### PR DESCRIPTION
This adds our `wiki` user to the Docker image, ensures that the generated config files are not world-readable and adds a call to `sudo` when running `docker-compose pull`.